### PR TITLE
Add support for iOS 16.7

### DIFF
--- a/updates.json
+++ b/updates.json
@@ -21,6 +21,7 @@
 		"16.4": "https://github.com/master131/iFakeLocation/releases/download/v1.7.0/iPhone-iPadOS-16.4.zip",
 		"16.5": "https://github.com/master131/iFakeLocation/releases/download/v1.7.0/iPhone-iPadOS-16.4.zip",
 		"16.6": "https://github.com/master131/iFakeLocation/releases/download/v1.7.0/iPhone-iPadOS-16.4.zip",
+		"16.7": "https://github.com/master131/iFakeLocation/releases/download/v1.7.0/iPhone-iPadOS-16.4.zip",
         "17.0": "https://github.com/master131/iFakeLocation/releases/download/v1.7.0/iPhone-iPadOS-Personalized-17.0.zip"
 	}
 }


### PR DESCRIPTION
The 16.4 image appears to still work for 16.7. Tested on iPhone X