### PR TITLE
Add Support for iOS 15.8

### DIFF
--- a/updates.json
+++ b/updates.json
@@ -14,6 +14,7 @@
 		"15.5": "https://github.com/master131/iFakeLocation/releases/download/v1.6.0/iPhone-iPadOS-15.5.zip",
 		"15.6": "https://github.com/master131/iFakeLocation/releases/download/v1.6.0/iPhone-iPadOS-15.6.zip",
 		"15.7": "https://github.com/master131/iFakeLocation/releases/download/v1.6.0/iPhone-iPadOS-15.7.zip",
+		"15.8": "https://github.com/master131/iFakeLocation/releases/download/v1.6.0/iPhone-iPadOS-15.7.zip",
 		"16.0": "https://github.com/master131/iFakeLocation/releases/download/v1.6.0/iPhone-iPadOS-16.0.zip",
 		"16.1": "https://github.com/master131/iFakeLocation/releases/download/v1.6.0/iPhone-iPadOS-16.1.zip",
 		"16.2": "https://github.com/master131/iFakeLocation/releases/download/v1.6.0/iPhone-iPadOS-16.1.zip",


### PR DESCRIPTION
Little PR to fix iOS 15.8 compatibility.
I have confirmed that the 15.7 image works on 15.8. Given it was just a security patch, I don't anticipate anything has changed under the hood. 

Cheers, 
ewand7